### PR TITLE
Partly revert commit 9a5a29c "Minor formatting changes. Relative imports changed to absolute"

### DIFF
--- a/Met4FoF_redundancy/agentMFred/redundancyAgents1.py
+++ b/Met4FoF_redundancy/agentMFred/redundancyAgents1.py
@@ -11,8 +11,8 @@ import numpy as np
 from agentMET4FOF.metrological_agents import MetrologicalAgent
 from time_series_metadata.scheme import MetaData
 
-from Met4FoF_redundancy.agentMFred.metrological_streams_v2 import MetrologicalMultiWaveGenerator
-from Met4FoF_redundancy.MFred.redundancy1 import calc_lcs, calc_lcss
+from .metrological_streams_v2 import MetrologicalMultiWaveGenerator
+from ..MFred.redundancy1 import calc_lcs, calc_lcss
 
 
 class MetrologicalMultiWaveGeneratorAgent(MetrologicalAgent):


### PR DESCRIPTION
In commit bac6ab78a8f4b22156ca502f2b694db6086375a2 we transformed all internal imports into relative imports to simplify reusing the code in other projects. It turns out if the tutorial scripts are called directly by something like `python redundancyAgents_tutorial_1` and not like in the unittests from another script, those relative imports fail. We discovered that and changed the relative to absolute imports back in commit bac6ab78a8f4b22156ca502f2b694db6086375a2. Actually this problem does not occur for the imports in _redundancyAgents1.py_ bbecause this is not supposed to be called directly at any time, so we change those imports back to relative.