### PR TITLE
changed absolute imports to relative imports

### DIFF
--- a/Met4FoF_redundancy/agentMFred/redundancyAgents1.py
+++ b/Met4FoF_redundancy/agentMFred/redundancyAgents1.py
@@ -11,8 +11,8 @@ import numpy as np
 from agentMET4FOF.metrological_agents import MetrologicalAgent
 from time_series_metadata.scheme import MetaData
 
-from Met4FoF_redundancy.agentMFred.metrological_streams_v2 import MetrologicalMultiWaveGenerator
-from Met4FoF_redundancy.MFred.redundancy1 import calc_lcs, calc_lcss
+from .metrological_streams_v2 import MetrologicalMultiWaveGenerator
+from ..MFred.redundancy1 import calc_lcs, calc_lcss
 
 
 class MetrologicalMultiWaveGeneratorAgent(MetrologicalAgent):

--- a/Met4FoF_redundancy/agentMFred/redundancyAgents_tutorial_1.py
+++ b/Met4FoF_redundancy/agentMFred/redundancyAgents_tutorial_1.py
@@ -8,8 +8,8 @@ import numpy as np
 from agentMET4FOF.agents import AgentNetwork
 from agentMET4FOF.metrological_agents import MetrologicalMonitorAgent
 
-from Met4FoF_redundancy.agentMFred.metrological_streams_v2 import MetrologicalMultiWaveGenerator
-from Met4FoF_redundancy.agentMFred.redundancyAgents1 import MetrologicalMultiWaveGeneratorAgent, RedundancyAgent
+from .metrological_streams_v2 import MetrologicalMultiWaveGenerator
+from .redundancyAgents1 import MetrologicalMultiWaveGeneratorAgent, RedundancyAgent
 
 
 def main():


### PR DESCRIPTION
In the previous merge, relative imports were replaced with absolute imports. This is no longer necessary and the relative imports have been restored.