### PR TITLE
Repair imports in ...tutorial_1

### DIFF
--- a/Met4FoF_redundancy_tutorials/redundancyAgents_tutorial_1.py
+++ b/Met4FoF_redundancy_tutorials/redundancyAgents_tutorial_1.py
@@ -8,8 +8,13 @@ import numpy as np
 from agentMET4FOF.agents import AgentNetwork
 from agentMET4FOF.metrological_agents import MetrologicalMonitorAgent
 
-from .metrological_streams_v2 import MetrologicalMultiWaveGenerator
-from .redundancyAgents1 import MetrologicalMultiWaveGeneratorAgent, RedundancyAgent
+from Met4FoF_redundancy.agentMFred.metrological_streams_v2 import (
+    MetrologicalMultiWaveGenerator,
+)
+from Met4FoF_redundancy.agentMFred.redundancyAgents1 import (
+    MetrologicalMultiWaveGeneratorAgent,
+    RedundancyAgent,
+)
 
 
 def main():


### PR DESCRIPTION
Somewhere along the way we lost some of  the reintroduced absolute imports needed in the tutorials. Tutorial 1 still contains some of them, which results in errors if executed directly or even in the pipeline.